### PR TITLE
chore: update Biome v2 config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,24 +7,15 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["./dist/**"]
+		"includes": ["**", "!!dist"]
 	},
 	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab"
-	},
-	"organizeImports": {
 		"enabled": true
 	},
 	"linter": {
 		"enabled": true,
 		"rules": {
 			"recommended": true
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double"
 		}
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "group:allNonMajor",
     ":assignAndReview(@nonoakij)",
     ":timezone(Asia/Tokyo)",
-    ":prHourlyLimitNone"
+    ":prHourlyLimitNone",
+    "customManagers:biomeVersions"
   ]
 }


### PR DESCRIPTION
## Summary

Biome を 2.4.16 に更新した後、v1 系の `biome.json` 設定が v2 の設定スキーマに合わず、`files.ignore` などが未対応キーとして扱われる状態になっていました。

この PR では Biome v2 で有効な設定形式に合わせ、`files.ignore` を `files.includes` の否定パターンへ移行しています。`dist` は出力物なので `!!dist` で Biome の処理・インデックス対象から除外します。

あわせて Renovate の `customManagers:biomeVersions` preset を追加し、Biome schema URL などの Biome version も Renovate の更新対象に含めます。

## Validation

- `./node_modules/.bin/biome check biome.json src/`
- commit hook: `npm run type-check`
